### PR TITLE
Add Gephi Toolkit documentation for Gephi 0.11.2

### DIFF
--- a/gephi-desktop/docs/Gephi_Toolkit/_category_.json
+++ b/gephi-desktop/docs/Gephi_Toolkit/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Gephi Toolkit",
+  "position": 3,
+  "link": {
+    "type": "doc",
+    "id": "Gephi_Toolkit/index"
+  }
+}

--- a/gephi-desktop/docs/Gephi_Toolkit/concurrency-and-server-applications.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/concurrency-and-server-applications.md
@@ -1,0 +1,102 @@
+---
+title: Concurrency and server applications
+sidebar_position: 9
+---
+
+The Toolkit can run inside a server application, but its project lifecycle is not isolated per request or per thread. `Lookup.getDefault()` returns application-wide services, and `ProjectController` manages one current project. That project, in turn, has one current workspace.
+
+This distinction matters in a SaaS application: thread-safe graph operations do not automatically provide request isolation.
+
+## Separate graph locking from request isolation
+
+The graph store exposes read and write locks and protects graph data structures during individual operations. This allows algorithms and application code to coordinate access to a particular graph.
+
+Project selection is a different layer. The current project and workspace are shared state, not `ThreadLocal` values. In particular, `projectController.newProject()` closes the project that is current at that moment. No-argument controller methods also resolve models through whichever workspace is current when the call occurs.
+
+Although the 0.11.2 `ProjectController` implementation synchronizes individual lifecycle methods, a sequence of calls is not one atomic transaction. Without application-level coordination, requests can interleave like this:
+
+```text
+Request A: newProject()      -> Project A is current
+Request B: newProject()      -> Project A is closed; Project B is current
+Request A: getCurrentWorkspace() -> receives Project B's workspace
+```
+
+Explicit `Workspace` and `GraphModel` references prevent accidental no-argument lookups, but they do not stop another request from closing or replacing the current project during initialization.
+
+## Use one critical section for the complete Toolkit workflow
+
+The simplest safe baseline in a request-based application is to serialize the complete Gephi portion of each request. Perform unrelated parsing or business calculations before entering the critical section, then keep project creation, graph construction or import, algorithms, export, and cleanup inside it.
+
+```java
+private static final Object GEPHI_LOCK = new Object();
+
+public String buildGraph(PreparedData data) {
+    synchronized (GEPHI_LOCK) {
+        ProjectController projectController = Lookup.getDefault()
+                .lookup(ProjectController.class);
+        GraphController graphController = Lookup.getDefault()
+                .lookup(GraphController.class);
+
+        Project project = projectController.newProject();
+        Workspace workspace = projectController.getCurrentWorkspace();
+
+        try {
+            GraphModel graphModel = graphController.getGraphModel(workspace);
+
+            // Populate this graph, run algorithms with graphModel,
+            // and configure exporters with this workspace explicitly.
+            return export(workspace);
+        } finally {
+            if (projectController.getCurrentProject() == project) {
+                projectController.closeCurrentProject();
+            }
+        }
+    }
+}
+```
+
+The identity check in `finally` documents which request owns the project and avoids closing an unrelated project if the code is later reorganized. It does not replace the lock: interference may already have occurred before cleanup.
+
+The same rule applies to `importController.process(container)`. That convenient overload uses the current project or creates one, so the call and all subsequent work on its returned workspace belong in the same critical section.
+
+:::warning A lock works only when every caller uses it
+
+A `static` lock coordinates callers in the same class loader only. Put Toolkit access behind one application service or another shared coordinator, and prevent other code paths from manipulating projects outside that boundary.
+
+:::
+
+## Prefer explicit objects after initialization
+
+Within the critical section, retain and pass the objects owned by the request:
+
+- obtain models with `graphController.getGraphModel(workspace)`;
+- configure layouts with that `GraphModel`;
+- set the `Workspace` explicitly on exporters;
+- avoid no-argument model accessors that depend on the current workspace;
+- close only the project created by that request.
+
+These practices make ownership visible and reduce accidental dependence on mutable current state. They are also useful in single-threaded applications with several workspaces.
+
+## Choose process isolation for real parallelism
+
+Serializing Toolkit work is safe but limits Gephi processing to one request at a time in each JVM. If layouts, statistics, or exports must run truly in parallel with strong tenant isolation, run independent Toolkit instances in separate JVM processes or workers. Each process then has its own default lookup, controllers, current project, and workspace state.
+
+Multiple workspaces in one project can support carefully controlled parallel algorithms when every algorithm receives a different explicit `GraphModel`. This is not equivalent to isolated concurrent request lifecycles: project and workspace selection remain shared, and any API that consults current state can still couple the tasks.
+
+## Lock compound access to one graph when needed
+
+Do not mutate the same graph from unrelated threads. When several operations on one graph must be observed as a unit, use its write lock and always release it in `finally`:
+
+```java
+Graph graph = graphModel.getGraph();
+graph.writeLock();
+try {
+    // Perform a compound graph update.
+} finally {
+    graph.writeUnlock();
+}
+```
+
+This graph lock protects a graph operation; it does not protect the global project lifecycle. Use the application-level critical section or process isolation for that broader boundary.
+
+See the [`ProjectController` 0.11.2 contract](https://javadoc.io/doc/org.gephi/gephi-toolkit/latest/org/gephi/project/api/ProjectController.html) for project and workspace lifecycle behavior.

--- a/gephi-desktop/docs/Gephi_Toolkit/core-concepts.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/core-concepts.md
@@ -1,0 +1,177 @@
+---
+title: Core concepts
+sidebar_position: 3
+---
+
+Gephi's API comes from a modular desktop application. The Toolkit keeps this architecture even though it runs without the Desktop interface. Understanding its services and document lifecycle makes the examples much easier to follow.
+
+## Lookup: ask Gephi for a service
+
+Code such as this can look unusual if you have not used the NetBeans Platform:
+
+```java
+ImportController importController = Lookup.getDefault()
+        .lookup(ImportController.class);
+```
+
+`Lookup` is a registry of services. Gephi modules register implementations, and your code asks for one by its public API type. You do not call `new ImportController(...)` because the concrete implementation and its dependencies are managed by the Toolkit.
+
+You can read the expression as: **give me the Toolkit service that implements `ImportController`**.
+
+Frequently used services include:
+
+| Service | Responsibility |
+| --- | --- |
+| `ImportController` | Parse inputs and process import containers |
+| `ExportController` | Find and run exporters |
+| `ProjectController` | Create and switch projects and workspaces |
+| `GraphController` | Find the graph model for a workspace |
+| `FilterController` | Build and execute filter queries |
+| `StatisticsController` | Execute statistics algorithms |
+| `AppearanceController` | Apply color, size, and label transformations |
+| `PreviewController` | Configure and refresh rendered output |
+
+Look up a controller once and reuse the reference in the current operation. A `null` result usually means the module providing that service is absent from the classpath.
+
+## Projects, workspaces, containers, and models
+
+These objects belong to two different layers. Projects and workspaces organize live Gephi documents. A container is an independent, temporary representation of graph data that can be populated by importers, generators, or application code and then consumed by a processor.
+
+```text
+Toolkit JVM
+└── ProjectController
+    └── Project
+        ├── Workspace A
+        │   ├── GraphModel
+        │   ├── AppearanceModel
+        │   ├── PreviewModel
+        │   └── other workspace-specific models
+        └── Workspace B
+            └── its own graph and models
+
+Importer, generator, or application code
+└── Container (temporary transferable graph data)
+    └── ImportController.process(...)
+        └── creates, fills, or updates a Workspace
+```
+
+### Project
+
+A **project** groups one or more workspaces. It is comparable to a Gephi Desktop project containing several graph tabs. `ProjectController` manages the open projects and tracks the current project and current workspace.
+
+:::warning `newProject()` closes the current project
+
+Calling `projectController.newProject()` creates and opens a new project with an initial workspace. It also closes the previously current project, so it should represent an intentional application-level boundary rather than a routine import step.
+
+In a multi-threaded server, current project and workspace state is shared between requests. See [Concurrency and server applications](./concurrency-and-server-applications.md) before initializing graphs concurrently.
+
+:::
+
+### Workspace
+
+A **workspace** is one working graph document, comparable to one tab in Gephi Desktop. It owns the graph and the state of modules such as appearance, filters, preview, and statistics.
+
+The graph itself is reached through the workspace's `GraphModel`:
+
+```java
+GraphController graphController = Lookup.getDefault()
+        .lookup(GraphController.class);
+GraphModel graphModel = graphController.getGraphModel(workspace);
+```
+
+Most models are created lazily the first time their controller is asked for them. A controller is generally an application-level service; a model contains the state for one workspace.
+
+Pass the `Workspace` explicitly whenever an API offers that overload. This makes the code safe when several workspaces exist and avoids depending on whichever workspace happens to be current.
+
+### Container
+
+A **container is not a workspace** and does not belong to a project. It is a temporary transfer object containing node, edge, and column drafts. File and database importers commonly populate containers, but graph generators and application code can populate them as well. Different processors can then use that data to create a workspace, append to an existing compatible workspace, or handle it in another supported way.
+
+A typical file import uses a container in two phases:
+
+```java
+Container container = importController.importFile(input);
+container.getLoader().setAllowAutoNode(false);
+
+Workspace workspace = importController.process(container);
+```
+
+Before processing, configure the loader and inspect the import report. `process` closes the loading phase, chooses a graph configuration from the container metadata, creates real graph objects in a workspace, and returns that workspace. Once a processor has transferred the drafts, continue with `GraphModel`, `Graph`, `Node`, and `Edge`; that container has completed its role in the operation.
+
+## Choose the correct initialization path
+
+The correct method depends on where the graph data comes from and whether a compatible workspace already exists.
+
+| Situation | Initialization | Result |
+| --- | --- | --- |
+| Import or generate data into a new workspace | `importController.process(container)` | Derives the graph configuration from the container. Opens a new workspace in the current project, or creates a project first if none is open. |
+| Build a simple graph directly with the Graph API | `projectController.newProject()`, then `getCurrentWorkspace()` | Creates a new project and its initial workspace. The `GraphModel` uses the default configuration when first requested. |
+| Build an empty graph with a deliberate configuration | `projectController.openNewWorkspace(configuration)` | Opens a new configured workspace in the current project, or creates a project first if needed. |
+| Add imported data to an existing compatible workspace | `process(container, new AppendProcessor(), workspace)` | Reuses that workspace and validates the incoming data against its existing graph configuration. |
+| Create a second version of an existing graph | `projectController.duplicateWorkspace(workspace)` | Creates another workspace with copied data and models. |
+
+`openNewWorkspace(...)` always makes the returned workspace current. If a project is already open, it adds the workspace to that project. If no project exists, it creates a project and its initial workspace.
+
+:::warning The graph configuration is fixed at workspace initialization
+
+In 0.11.2, ID types, temporal representation, edge-label type, and dynamic weight type must be correct when the `GraphModel` is created. An import container carries enough metadata for `process(container)` to derive these choices. This is why imported data should not normally be preceded by `newProject()` and a default graph model.
+
+:::
+
+## Direct graph construction without a container
+
+Most demos start from imported or generated drafts:
+
+```java
+Container container = importController.importFile(input);
+Workspace workspace = importController.process(container);
+```
+
+Code that creates nodes and edges directly through the Graph API has no container for `ImportController` to process. It must initialize an empty workspace through `ProjectController` instead.
+
+For a simple graph using default settings, this concise form is sufficient:
+
+```java
+projectController.newProject();
+Workspace workspace = projectController.getCurrentWorkspace();
+```
+
+This more explicit form is useful when the workspace needs a particular configuration:
+
+```java
+Configuration configuration = graphController
+        .getDefaultConfigurationBuilder()
+        .build();
+Workspace workspace = projectController.openNewWorkspace(configuration);
+```
+
+For basic static nodes and edges, both paths provide a suitable empty workspace. The important distinction is **who has the information needed to choose the workspace configuration**. A container lets its processor choose from the metadata it carries. Without a container, your code accepts the defaults or supplies the configuration itself.
+
+## Full graph and visible graph
+
+A workspace can expose several views over the same graph store:
+
+- `graphModel.getGraph()` returns the main graph;
+- `graphModel.getGraphVisible()` returns the current visible view;
+- typed variants such as `getDirectedGraph()` and `getUndirectedGraphVisible()` change how edges are interpreted.
+
+Filters produce a `GraphView`. Setting it as visible does not delete elements from the main graph:
+
+```java
+GraphView view = filterController.filter(query);
+graphModel.setVisibleView(view);
+Graph filteredGraph = graphModel.getGraphVisible();
+```
+
+Layouts normally operate on the visible view. Graph exporters can be configured to export either the full graph or only that view.
+
+## A practical rule for API navigation
+
+When translating a Desktop action into code, find the corresponding module, then identify:
+
+1. the controller obtained through `Lookup`;
+2. the workspace-specific model, if that module has one;
+3. the algorithm, filter, transformer, importer, or exporter to configure;
+4. the method that executes it.
+
+The [Javadoc](https://javadoc.io/doc/org.gephi/gephi-toolkit/latest/index.html) documents API contracts. The [Toolkit demos](https://github.com/gephi/gephi-toolkit-demos) show which implementations are normally instantiated directly and which services come from `Lookup`.

--- a/gephi-desktop/docs/Gephi_Toolkit/dynamic-graphs-and-workspaces.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/dynamic-graphs-and-workspaces.md
@@ -1,0 +1,122 @@
+---
+title: Dynamic graphs and workspaces
+sidebar_position: 8
+---
+
+Temporal representation and element ID types belong to a workspace's graph configuration. In Gephi 0.11.2 that configuration is immutable, so it must be correct when the workspace is created.
+
+## Let imports create the workspace
+
+For imported or generated data, this is the safest workflow:
+
+```java
+Container container = importController.importFile(new File("dynamic.gexf"));
+Workspace workspace = importController.process(container);
+GraphModel graphModel = graphController.getGraphModel(workspace);
+```
+
+The processor reads the container metadata and configures timestamp versus interval time representation, ID types, edge labels, and dynamic edge weights as needed.
+
+This replaces the pre-0.11 pattern of creating a default empty workspace first and processing dynamic data into it.
+
+## Generate dynamic sample data
+
+The bundled [`DynamicGraph`](https://github.com/gephi/gephi/blob/master/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/DynamicGraph.java) class is a graph generator, despite its general-sounding name. It is useful for examples, tests, and experiments that need temporal data without an input file. The generator creates timestamped node presence, a dynamic integer node column named `score`, and dynamic edge weights.
+
+Like the other bundled generators, it writes drafts into a container. Processing that container lets Gephi derive the required timestamp and dynamic-weight configuration:
+
+```java
+import org.gephi.io.generator.plugin.DynamicGraph;
+import org.gephi.io.importer.api.Container;
+import org.openide.util.Lookup;
+
+Container container = Lookup.getDefault()
+        .lookup(Container.Factory.class)
+        .newContainer();
+
+DynamicGraph generator = new DynamicGraph();
+generator.generate(container.getLoader());
+
+Workspace workspace = importController.process(container);
+GraphModel graphModel = graphController.getGraphModel(workspace);
+```
+
+`DynamicGraph` is not the API used to query arbitrary temporal graphs. Once its generated container has been processed, use `GraphModel`, element timestamps or intervals, dynamic columns, and time-aware statistics in the same way as for imported temporal data.
+
+## Create a configured empty workspace
+
+When constructing a graph manually, choose its temporal representation before adding data:
+
+```java
+import org.gephi.graph.api.Configuration;
+import org.gephi.graph.api.TimeRepresentation;
+
+Configuration configuration = Configuration.builder()
+        .timeRepresentation(TimeRepresentation.TIMESTAMP)
+        .build();
+Workspace workspace = projectController.openNewWorkspace(configuration);
+```
+
+Use `TimeRepresentation.INTERVAL` when values describe start/end intervals. Use `TIMESTAMP` when values are observations at discrete times. Do not attempt to change this choice later; create another correctly configured workspace instead.
+
+## Add temporal presence
+
+For interval time representation, a node can be present from a start time to an end time:
+
+```java
+import org.gephi.graph.api.Interval;
+
+node.addInterval(new Interval(1990, 2000));
+```
+
+Dynamic columns use map types such as `TimestampIntegerMap`, `TimestampDoubleMap`, or their interval equivalents. Cast only after checking the column's type, especially for user-supplied files.
+
+## Merge several snapshots
+
+Several containers can be merged into temporal data:
+
+```java
+import org.gephi.io.processor.plugin.MergeProcessor;
+
+Container[] snapshots = {first, second, third};
+Workspace workspace = importController.process(
+        snapshots, new MergeProcessor(), null)[0];
+```
+
+Passing `null` lets the processor create a correctly configured destination. Element IDs determine which nodes and edges across snapshots represent the same entity.
+
+The [`ImportDynamic.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/ImportDynamic.java) demo reads timestamped values after merging snapshots. [`DynamicMetric.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/DynamicMetric.java) computes degree over time windows.
+
+## Work with several workspaces
+
+Keep each workspace and its models together in your application code:
+
+```java
+Workspace firstWorkspace = importController.process(firstContainer);
+GraphModel firstModel = graphController.getGraphModel(firstWorkspace);
+
+Workspace secondWorkspace = importController.process(secondContainer);
+GraphModel secondModel = graphController.getGraphModel(secondWorkspace);
+```
+
+Avoid no-argument accessors such as `getGraphModel()` or `getModel()` in multi-workspace code. They use the current workspace, which can change as projects and workspaces are opened.
+
+Independent layouts can run concurrently on different workspaces when each layout receives its own explicit `GraphModel` and the project lifecycle remains stable, as shown in [`ParallelWorkspace.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/ParallelWorkspace.java). This does not make concurrent project creation or current-workspace access request-safe. Do not mutate the same graph from unrelated threads, and see [Concurrency and server applications](./concurrency-and-server-applications.md) before using the Toolkit from concurrent requests.
+
+## Migrate code written for older Toolkit versions
+
+Replace this old import sequence:
+
+```java
+projectController.newProject();
+Workspace workspace = projectController.getCurrentWorkspace();
+importController.process(container, new DefaultProcessor(), workspace);
+```
+
+with:
+
+```java
+Workspace workspace = importController.process(container);
+```
+
+For a genuinely empty graph, use `openNewWorkspace(configuration)`. For appending data, keep the existing workspace and use `AppendProcessor`; the existing graph configuration must already be compatible with the incoming container.

--- a/gephi-desktop/docs/Gephi_Toolkit/filtering-analysis-appearance.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/filtering-analysis-appearance.md
@@ -1,0 +1,116 @@
+---
+title: Filter, analyze, and style
+sidebar_position: 6
+---
+
+A typical Toolkit pipeline filters a graph, computes metrics, and maps data values to visual properties. These operations use three different APIs but share the same workspace.
+
+## Filter into a visible view
+
+This example keeps nodes with degree 10 or greater:
+
+```java
+import org.gephi.filters.api.FilterController;
+import org.gephi.filters.api.Query;
+import org.gephi.filters.api.Range;
+import org.gephi.filters.plugin.graph.DegreeRangeBuilder.DegreeRangeFilter;
+import org.gephi.graph.api.GraphView;
+
+FilterController filterController = Lookup.getDefault()
+        .lookup(FilterController.class);
+
+DegreeRangeFilter degreeFilter = new DegreeRangeFilter();
+degreeFilter.init(graphModel.getGraph());
+degreeFilter.setRange(new Range(10, Integer.MAX_VALUE));
+
+Query query = filterController.createQuery(degreeFilter);
+GraphView filteredView = filterController.filter(query);
+graphModel.setVisibleView(filteredView);
+```
+
+Read the result with `graphModel.getGraphVisible()`. The main graph remains intact.
+
+Filters can form a query tree. An intersection operator with two subqueries means both conditions must match. The [`Filtering.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/Filtering.java) demo includes degree, partition, intersection, and ego filters.
+
+To return to the complete graph:
+
+```java
+graphModel.setVisibleView(graphModel.getGraph().getView());
+```
+
+Destroy views that are no longer needed in long-running applications:
+
+```java
+graphModel.destroyView(filteredView);
+```
+
+Do not destroy the main view.
+
+## Run a statistic
+
+Algorithms such as graph distance write their results into graph attributes:
+
+```java
+import org.gephi.graph.api.Column;
+import org.gephi.statistics.plugin.GraphDistance;
+
+GraphDistance distance = new GraphDistance();
+distance.setDirected(true);
+distance.execute(graphModel);
+
+Column betweenness = graphModel.getNodeTable()
+        .getColumn(GraphDistance.BETWEENNESS);
+```
+
+Choose directedness and other parameters deliberately; they change the meaning of the result. Depending on the algorithm, executing against the model may use its visible graph. Decide whether filtering is part of the analysis before running a statistic.
+
+Some metrics are executed through `StatisticsController`, especially when the controller coordinates execution or progress. Follow the API used by the concrete statistic and consult the [0.11.2 Javadoc](https://gephi.org/gephi-toolkit/0.11.2/apidocs/).
+
+## Map data to color or size
+
+The Appearance API creates a function from a column and a transformer type:
+
+```java
+import java.awt.Color;
+import org.gephi.appearance.api.AppearanceController;
+import org.gephi.appearance.api.AppearanceModel;
+import org.gephi.appearance.api.Function;
+import org.gephi.appearance.plugin.RankingElementColorTransformer;
+import org.gephi.appearance.plugin.RankingNodeSizeTransformer;
+
+AppearanceController appearanceController = Lookup.getDefault()
+        .lookup(AppearanceController.class);
+AppearanceModel appearanceModel = appearanceController.getModel(workspace);
+
+Function colorFunction = appearanceModel.getNodeFunction(
+        graphModel.defaultColumns().degree(),
+        RankingElementColorTransformer.class);
+RankingElementColorTransformer colorTransformer = colorFunction.getTransformer();
+colorTransformer.setColors(new Color[] {
+    new Color(0xFEF0D9), new Color(0xB30000)
+});
+colorTransformer.setColorPositions(new float[] {0f, 1f});
+appearanceController.transform(colorFunction);
+
+Function sizeFunction = appearanceModel.getNodeFunction(
+        betweenness, RankingNodeSizeTransformer.class);
+RankingNodeSizeTransformer sizeTransformer = sizeFunction.getTransformer();
+sizeTransformer.setMinSize(3f);
+sizeTransformer.setMaxSize(20f);
+appearanceController.transform(sizeFunction);
+```
+
+Always check that an imported or computed column exists before building a function in production code. A misspelled column ID otherwise turns into a less informative failure later in the pipeline.
+
+## Recommended ordering
+
+For many workflows, this order is predictable:
+
+1. import or build the graph;
+2. create and select a filtered view, if required;
+3. run statistics;
+4. apply appearance transformations;
+5. run a layout;
+6. configure preview and export.
+
+Change the order intentionally when a metric should describe the full graph but the final image should show only a subset.

--- a/gephi-desktop/docs/Gephi_Toolkit/getting-started.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/getting-started.md
@@ -1,0 +1,209 @@
+---
+title: Getting started
+sidebar_position: 2
+---
+
+This page creates a small command-line application that imports a graph, inspects it, and exports it again.
+
+## Requirements
+
+- JDK 17 or later;
+- Apache Maven 3.6.3 or later;
+- a GEXF, GML, GraphML, CSV, or another [supported graph file](../User_Manual/Import/index.md).
+
+Check the tools used by your terminal:
+
+```bash
+java -version
+mvn -version
+```
+
+Both commands should report Java 17 or later.
+
+## Create the Maven project
+
+Use this minimal directory structure:
+
+```text
+toolkit-example/
+|-- .mvn/
+|   `-- jvm.config
+|-- input.gexf
+|-- pom.xml
+`-- src/
+    `-- main/
+        `-- java/
+            `-- example/
+                `-- Main.java
+```
+
+The Toolkit requires access to `java.net` through Java's module system. Create
+`.mvn/jvm.config` with this JVM option:
+
+```text
+--add-opens=java.base/java.net=ALL-UNNAMED
+```
+
+Maven reads this file automatically, so the option applies whenever the example
+is run from the project directory.
+
+Add the Toolkit and a convenient execution plugin to `pom.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>example</groupId>
+  <artifactId>toolkit-example</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.gephi</groupId>
+      <artifactId>gephi-toolkit</artifactId>
+      <version>0.11.2</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <mainClass>example.Main</mainClass>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+The `cleanupDaemonThreads` setting lets Maven terminate harmless background threads started by Gephi and NetBeans services when the program finishes.
+
+Download the supplied [Les Misérables `input.gexf`](./input.gexf) and save it as
+`input.gexf` at the root of the Maven project, next to `pom.xml`.
+
+## Write the first pipeline
+
+Create `src/main/java/example/Main.java`:
+
+```java
+package example;
+
+import java.io.File;
+import org.gephi.graph.api.Graph;
+import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.io.exporter.api.ExportController;
+import org.gephi.io.importer.api.Container;
+import org.gephi.io.importer.api.ImportController;
+import org.gephi.project.api.Workspace;
+import org.openide.util.Lookup;
+
+public class Main {
+
+    public static void main(String[] args) {
+        int exitCode = run(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    private static int run(String[] args) {
+        if (args.length != 2) {
+            System.err.println("Usage: Main <input.gexf> <output.graphml>");
+            return 1;
+        }
+
+        File input = new File(args[0]);
+        File output = new File(args[1]);
+
+        if (!input.isFile() || !input.canRead()) {
+            System.err.printf("Cannot read input file: %s%n", input);
+            return 1;
+        }
+
+        try {
+            ImportController importController = Lookup.getDefault()
+                    .lookup(ImportController.class);
+
+            Container container = importController.importFile(input);
+            if (container == null) {
+                System.err.printf(
+                        "Could not import %s: unsupported or invalid file%n",
+                        input);
+                return 1;
+            }
+            Workspace workspace = importController.process(container);
+
+            GraphModel graphModel = Lookup.getDefault()
+                    .lookup(GraphController.class)
+                    .getGraphModel(workspace);
+            Graph graph = graphModel.getGraph();
+
+            System.out.printf("Imported %d nodes and %d edges%n",
+                    graph.getNodeCount(), graph.getEdgeCount());
+
+            ExportController exportController = Lookup.getDefault()
+                    .lookup(ExportController.class);
+            exportController.exportFile(output);
+            return 0;
+        } catch (Exception exception) {
+            String detail = exception.getMessage();
+            if (detail == null || detail.isBlank()) {
+                detail = exception.getClass().getSimpleName();
+            }
+            System.err.printf("Could not process %s: %s%n", input, detail);
+            return 1;
+        }
+    }
+}
+```
+
+Run it from the project directory:
+
+```bash
+mvn compile exec:java -Dexec.args="input.gexf output.graphml"
+```
+
+The output format is selected from the file extension. Replace the paths with files on your machine.
+
+## Understand the five steps
+
+1. `Lookup` supplies Gephi services called **controllers**.
+2. `importFile` parses the input into an intermediate `Container`.
+3. `process(container)` creates a correctly configured `Workspace`, then copies the imported data into it. It uses the current project or creates one if necessary.
+4. `GraphController` supplies the `GraphModel` owned by that workspace.
+5. `ExportController` selects an exporter from the output extension.
+
+The distinction between a controller, a workspace, and a model matters as soon as an application processes more than one graph. [Core concepts](./core-concepts.md) explains it in detail.
+
+:::tip Use paths during development
+
+The official demos load sample files with `getResource(...)` because those files are bundled in their JAR. For user-selected or server-side files, passing a `File` or stream directly is usually simpler.
+
+:::
+
+## Explore the demos
+
+Clone the [Toolkit demos](https://github.com/gephi/gephi-toolkit-demos) and run:
+
+```bash
+git clone https://github.com/gephi/gephi-toolkit-demos.git
+cd gephi-toolkit-demos
+mvn compile exec:java
+```
+
+`Main.java` runs the command-line demos in sequence. `PreviewJFrame.java` is a separate graphical Swing example and is not part of that sequence.

--- a/gephi-desktop/docs/Gephi_Toolkit/graph-model.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/graph-model.md
@@ -1,0 +1,124 @@
+---
+title: Create and manipulate graphs
+sidebar_position: 4
+---
+
+Use the Graph API after an import has been processed, or to build a graph entirely in Java.
+
+## Create an empty workspace
+
+When no import can infer the graph configuration, create the workspace explicitly:
+
+```java
+import org.gephi.graph.api.Configuration;
+import org.gephi.graph.api.GraphController;
+import org.gephi.graph.api.GraphModel;
+import org.gephi.project.api.ProjectController;
+import org.gephi.project.api.Workspace;
+import org.openide.util.Lookup;
+
+ProjectController projectController = Lookup.getDefault()
+        .lookup(ProjectController.class);
+GraphController graphController = Lookup.getDefault()
+        .lookup(GraphController.class);
+Workspace workspace = projectController.openNewWorkspace(
+        graphController.getDefaultConfigurationBuilder().build());
+
+GraphModel graphModel = graphController.getGraphModel(workspace);
+```
+
+The default configuration is suitable for ordinary non-temporal node and edge values. Dynamic graphs and non-default ID types need a deliberate configuration; see [Dynamic graphs and workspaces](./dynamic-graphs-and-workspaces.md).
+
+## Add nodes and edges
+
+Create elements with the model's factory, then add them to a graph:
+
+```java
+import org.gephi.graph.api.DirectedGraph;
+import org.gephi.graph.api.Edge;
+import org.gephi.graph.api.Node;
+
+Node alice = graphModel.factory().newNode("alice");
+alice.setLabel("Alice");
+
+Node bob = graphModel.factory().newNode("bob");
+bob.setLabel("Bob");
+
+Edge follows = graphModel.factory().newEdge(
+        alice, bob, 0, 1.0, true);
+
+DirectedGraph graph = graphModel.getDirectedGraph();
+graph.addNode(alice);
+graph.addNode(bob);
+graph.addEdge(follows);
+```
+
+The arguments after the nodes are the edge type, weight, and directed flag. Node and edge IDs must match the ID types chosen in the workspace configuration.
+
+:::note Choose the correct graph view
+
+`DirectedGraph` preserves edge direction. `UndirectedGraph` treats edges as undirected. `Graph` works for mixed graphs. These interfaces are views of the same underlying store; requesting an undirected view does not rewrite the stored edges.
+
+:::
+
+## Read graph structure
+
+```java
+System.out.println(graph.getNodeCount());
+System.out.println(graph.getEdgeCount());
+
+Node node = graph.getNode("alice");
+int degree = graph.getDegree(node);
+
+for (Node neighbor : graph.getNeighbors(node)) {
+    System.out.println(neighbor.getId());
+}
+
+for (Edge edge : graph.getEdges()) {
+    System.out.printf("%s -> %s%n",
+            edge.getSource().getId(), edge.getTarget().getId());
+}
+```
+
+Prefer IDs for durable references. Labels are display data and do not have to be unique.
+
+## Add and use attributes
+
+Columns define an attribute's ID and Java type. Nodes or edges hold the values:
+
+```java
+import org.gephi.graph.api.Column;
+
+Column activeColumn = graphModel.getNodeTable()
+        .addColumn("active", Boolean.class);
+
+alice.setAttribute(activeColumn, Boolean.TRUE);
+Boolean active = (Boolean) alice.getAttribute(activeColumn);
+```
+
+Retrieve imported columns from the node or edge table:
+
+```java
+Column categoryColumn = graphModel.getNodeTable().getColumn("category");
+Object category = alice.getAttribute(categoryColumn);
+```
+
+Using a `Column` reference is faster and safer inside a large loop than repeatedly looking up a value by its string ID.
+
+Column types matter. Do not store a `String` such as `"42"` in an `Integer` column. Dynamic attributes use specialized map types rather than ordinary scalar values.
+
+## Modify while iterating
+
+Graph iterables hold read locks. Copy elements to an array before removing them from the same graph:
+
+```java
+for (Node node : graph.getNodes().toArray()) {
+    if (graph.getDegree(node) == 0) {
+        graph.removeNode(node);
+    }
+}
+```
+
+Removing directly inside `for (Node node : graph.getNodes())` can conflict with the iterable's lock.
+
+See [`ManualGraph.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/ManualGraph.java) and [`ManipulateAttributes.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/ManipulateAttributes.java) for complete examples.

--- a/gephi-desktop/docs/Gephi_Toolkit/import-export.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/import-export.md
@@ -1,0 +1,136 @@
+---
+title: Import and export
+sidebar_position: 5
+---
+
+Importers translate external data into a `Container`, while generators create container data programmatically. Processors then copy that container into a workspace. Exporters translate a workspace to a file, writer, or stream.
+
+## Import a file
+
+```java
+ImportController importController = Lookup.getDefault()
+        .lookup(ImportController.class);
+
+Container container = importController.importFile(new File("network.gexf"));
+Workspace workspace = importController.process(container);
+```
+
+The importer is normally selected from the file extension. Supported formats include GEXF, GML, GraphML, GDF, CSV, Pajek NET, UCINET DL, GraphViz DOT, Tulip TPL, and VNA. See the [file format documentation](../User_Manual/Import/index.md) for format-specific rules.
+
+## Configure the staged import
+
+Change loader options before calling `process`:
+
+```java
+import org.gephi.io.importer.api.EdgeDirectionDefault;
+
+container.getLoader().setEdgeDefault(EdgeDirectionDefault.DIRECTED);
+container.getLoader().setAllowAutoNode(false);
+```
+
+- `setEdgeDefault` supplies a direction when the source format does not specify one, or deliberately overrides it.
+- `setAllowAutoNode(false)` prevents edges that reference unknown node IDs from silently creating those nodes.
+
+The container's report records warnings and errors produced during parsing. Inspect it when accepting files from users, even when import succeeds.
+
+:::warning Treat imports as untrusted input
+
+Catch import exceptions at your application boundary and return a useful message that includes the input name. Gephi 0.11.2 defines specific import exceptions for known failures such as empty files; do not reduce every failure to a generic “graph could not be loaded” message.
+
+:::
+
+## Generate data into a container
+
+Generators use the same container-and-processor pipeline as file and database importers. In a Toolkit application, create a container, let the generator populate its loader, and then process it:
+
+```java
+import org.gephi.io.generator.plugin.RandomGraph;
+import org.gephi.io.importer.api.Container;
+
+Container container = Lookup.getDefault()
+        .lookup(Container.Factory.class)
+        .newContainer();
+
+RandomGraph generator = new RandomGraph();
+generator.setNumberOfNodes(500);
+generator.setWiringProbability(0.005);
+generator.generate(container.getLoader());
+
+Workspace workspace = importController.process(container);
+```
+
+The bundled generator package contains three graph-producing classes:
+
+- [`RandomGraph`](https://github.com/gephi/gephi/blob/master/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/RandomGraph.java) creates a configurable random graph;
+- [`MultiGraph`](https://github.com/gephi/gephi/blob/master/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/MultiGraph.java) provides sample data with edge types and parallel edges;
+- [`DynamicGraph`](https://github.com/gephi/gephi/blob/master/modules/GeneratorPlugin/src/main/java/org/gephi/io/generator/plugin/DynamicGraph.java) provides timestamped sample data with dynamic attributes and is discussed in [Dynamic graphs and workspaces](./dynamic-graphs-and-workspaces.md#generate-dynamic-sample-data).
+
+These implementations are convenient for demonstrations and test fixtures. They also show how a custom `Generator` can create `NodeDraft`, `EdgeDraft`, and column data through `ContainerLoader`. `RandomGraphUI` is a Desktop UI integration point and is not needed for headless Toolkit use.
+
+## Append to an existing workspace
+
+The convenient `process(container)` method creates a new workspace in the current project, or creates a project first if none exists. To add data to an existing workspace instead, select a processor and destination explicitly:
+
+```java
+import org.gephi.io.processor.plugin.AppendProcessor;
+
+importController.process(container, new AppendProcessor(), workspace);
+```
+
+IDs control whether elements are new or match existing data. Verify node and edge counts after appending, particularly when several sources may reuse IDs.
+
+For several temporal snapshots, `MergeProcessor` can process an array of containers. The [`ImportDynamic.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/ImportDynamic.java) demo shows that workflow.
+
+## Export from the current workspace
+
+The simplest export selects the exporter from the output extension:
+
+```java
+ExportController exportController = Lookup.getDefault()
+        .lookup(ExportController.class);
+exportController.exportFile(new File("result.gexf"));
+```
+
+For applications with multiple workspaces, configure the exporter explicitly:
+
+```java
+import org.gephi.io.exporter.spi.GraphExporter;
+
+GraphExporter exporter = (GraphExporter) exportController.getExporter("graphml");
+exporter.setWorkspace(workspace);
+exportController.exportFile(new File("result.graphml"), exporter);
+```
+
+## Export only a filtered graph
+
+Graph exporters use the full graph by default. To export the visible view created by a filter:
+
+```java
+GraphExporter exporter = (GraphExporter) exportController.getExporter("gexf");
+exporter.setExportVisible(true);
+exporter.setWorkspace(workspace);
+exportController.exportFile(new File("filtered.gexf"), exporter);
+```
+
+Setting a filter's `GraphView` as visible and setting `setExportVisible(true)` are both required.
+
+## Export to memory
+
+Character formats can be written to a `Writer`:
+
+```java
+import java.io.StringWriter;
+import org.gephi.io.exporter.spi.CharacterExporter;
+import org.gephi.io.exporter.spi.Exporter;
+
+Exporter graphml = exportController.getExporter("graphml");
+graphml.setWorkspace(workspace);
+
+StringWriter writer = new StringWriter();
+exportController.exportWriter(writer, (CharacterExporter) graphml);
+String serializedGraph = writer.toString();
+```
+
+Binary exporters, including PDF, can write to an `OutputStream`. This is useful in a web service where the result is sent in an HTTP response rather than saved locally.
+
+See [`ImportExport.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/ImportExport.java) for file, writer, and byte-array examples, and [`SQLiteImportExport.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/SQLiteImportExport.java) for database import.

--- a/gephi-desktop/docs/Gephi_Toolkit/index.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/index.md
@@ -1,0 +1,58 @@
+---
+id: index
+title: Gephi Toolkit
+sidebar_position: 1
+slug: /Gephi_Toolkit
+---
+
+The Gephi Toolkit is a Java library for working with graphs without running the Gephi Desktop user interface. It uses the same core modules as Gephi Desktop, including import, graph manipulation, filters, statistics, layouts, appearance, preview, and export.
+
+Use the Toolkit when you want to:
+
+- automate a repeatable graph-processing workflow;
+- add network analysis to a Java application;
+- run layouts or statistics on a server;
+- generate GEXF, GraphML, SVG, PDF, or other outputs programmatically.
+
+This guide targets developers who know basic Java but are new to Gephi's architecture and the NetBeans Platform idioms used by its API. It documents **Gephi Toolkit 0.11.2**, which requires **Java 17 or later**.
+
+:::info Toolkit and Desktop
+
+The Toolkit is not a remote control for an open Gephi Desktop window. It runs Gephi's processing modules inside your own JVM. There is no Overview or Data Laboratory window, and no graphical interface to configure algorithms: your Java code supplies every input and option.
+
+:::
+
+## Start here
+
+1. Follow [Getting started](./getting-started.md) to create and run a minimal Maven project.
+2. Read [Core concepts](./core-concepts.md) before combining several Toolkit features.
+3. Continue with the task-oriented pages in this section.
+
+The [official Toolkit demos](https://github.com/gephi/gephi-toolkit-demos) contain complete programs for Gephi 0.11.2. This guide explains the architecture and the non-obvious API choices behind those programs.
+
+## What is included
+
+Most features that do not depend on the Desktop interface are available:
+
+- graph creation and manipulation;
+- file and database import;
+- graph, data, and preview export;
+- filters and graph views;
+- statistics and metrics;
+- layouts;
+- appearance transformations;
+- preview rendering;
+- dynamic graphs and multiple workspaces;
+- [concurrency and request isolation in server applications](./concurrency-and-server-applications.md).
+
+Desktop **Tools** are not included because they are interactive mouse or interface actions. Some third-party plugins can be used if their core module does not depend on Desktop-only APIs.
+
+## Reference material
+
+- [Gephi Toolkit main page](https://gephi.org/toolkit/)
+- [Gephi Toolkit Javadoc](https://javadoc.io/doc/org.gephi/gephi-toolkit/latest/index.html)
+- [Gephi Toolkit releases](https://github.com/gephi/gephi-toolkit/releases)
+- [Gephi Toolkit demos](https://github.com/gephi/gephi-toolkit-demos)
+- [Gephi file formats](../User_Manual/Import/index.md)
+
+If an example and the Javadoc appear to disagree, first verify that both target version 0.11.2. Older examples commonly create projects and workspaces in a way that is no longer appropriate for 0.11.2.

--- a/gephi-desktop/docs/Gephi_Toolkit/input.gexf
+++ b/gephi-desktop/docs/Gephi_Toolkit/input.gexf
@@ -1,0 +1,887 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gexf xmlns="http://gexf.net/1.3" version="1.3" xmlns:viz="http://gexf.net/1.3/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd">
+  <meta lastmodifieddate="2026-08-26">
+    <creator>Gephi 0.11.2</creator>
+    <title></title>
+    <description></description>
+  </meta>
+  <graph defaultedgetype="undirected" mode="static">
+    <attributes class="node" mode="static">
+      <attribute id="modularity_class" title="Modularity Class" type="integer"/>
+    </attributes>
+    <nodes>
+      <node id="11" label="Valjean">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="100.0"/>
+        <viz:position x="-87.93029" y="6.8120565"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="48" label="Gavroche">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="61.600006"/>
+        <viz:position x="387.89572" y="-110.462326"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="55" label="Marius">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="53.37143"/>
+        <viz:position x="206.44687" y="13.805411"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="27" label="Javert">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="47.88571"/>
+        <viz:position x="-81.46074" y="204.20204"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="25" label="Thenardier">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="45.142853"/>
+        <viz:position x="82.80825" y="203.1144"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="23" label="Fantine">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="42.4"/>
+        <viz:position x="-313.42786" y="289.44803"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="58" label="Enjolras">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="42.4"/>
+        <viz:position x="355.78366" y="74.882454"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="62" label="Courfeyrac">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="36.91429"/>
+        <viz:position x="436.17184" y="12.7286825"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="64" label="Bossuet">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="36.91429"/>
+        <viz:position x="455.81955" y="115.45826"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="63" label="Bahorel">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="34.17143"/>
+        <viz:position x="602.55225" y="-16.421427"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="65" label="Joly">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="34.17143"/>
+        <viz:position x="516.40784" y="-47.242233"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="24" label="MmeThenardier">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="31.428574"/>
+        <viz:position x="4.6313396" y="273.8517"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="26" label="Cosette">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="31.428574"/>
+        <viz:position x="78.64646" y="31.512747"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="41" label="Eponine">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="31.428574"/>
+        <viz:position x="238.36697" y="210.00926"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="57" label="Mabeuf">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="31.428574"/>
+        <viz:position x="597.6618" y="-135.18481"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="59" label="Combeferre">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="31.428574"/>
+        <viz:position x="515.2961" y="46.167564"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="61" label="Feuilly">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="31.428574"/>
+        <viz:position x="550.1917" y="128.17537"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="0" label="Myriel">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="28.685715"/>
+        <viz:position x="-266.82776" y="-299.6904"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="66" label="Grantaire">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="28.685715"/>
+        <viz:position x="646.4313" y="151.06331"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="68" label="Gueulemer">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="28.685715"/>
+        <viz:position x="78.4799" y="347.15146"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="69" label="Babet">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="28.685715"/>
+        <viz:position x="150.35959" y="298.50797"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="70" label="Claquesous">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="28.685715"/>
+        <viz:position x="137.3717" y="410.2809"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="16" label="Tholomyes">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="25.942856"/>
+        <viz:position x="-385.2226" y="393.5572"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="60" label="Prouvaire">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="25.942856"/>
+        <viz:position x="614.29285" y="69.3104"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="71" label="Montparnasse">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="25.942856"/>
+        <viz:position x="234.87747" y="400.85983"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="29" label="Bamatabois">
+        <attvalues>
+          <attvalue for="modularity_class" value="3"/>
+        </attvalues>
+        <viz:size value="23.2"/>
+        <viz:position x="-385.6842" y="20.206686"/>
+        <viz:color r="194" g="245" b="91"/>
+      </node>
+      <node id="17" label="Listolier">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="-516.55884" y="393.98975"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="18" label="Fameuil">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="-464.79382" y="493.57944"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="19" label="Blacheville">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="-515.1624" y="456.9891"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="20" label="Favourite">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="-408.12122" y="464.5048"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="21" label="Dahlia">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="-456.44113" y="425.13303"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="22" label="Zephine">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="-459.1107" y="362.5133"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="49" label="Gillenormand">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="126.4831" y="-68.10622"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="51" label="MlleGillenormand">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="162.63559" y="-117.6565"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="75" label="Brujon">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="238.79364" y="314.06345"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="76" label="MmeHucheloup">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="20.457146"/>
+        <viz:position x="712.18353" y="-4.8131495"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="34" label="Judge">
+        <attvalues>
+          <attvalue for="modularity_class" value="3"/>
+        </attvalues>
+        <viz:size value="17.714287"/>
+        <viz:position x="-387.84915" y="-58.7059"/>
+        <viz:color r="194" g="245" b="91"/>
+      </node>
+      <node id="35" label="Champmathieu">
+        <attvalues>
+          <attvalue for="modularity_class" value="3"/>
+        </attvalues>
+        <viz:size value="17.714287"/>
+        <viz:position x="-338.2307" y="-87.48405"/>
+        <viz:color r="194" g="245" b="91"/>
+      </node>
+      <node id="36" label="Brevet">
+        <attvalues>
+          <attvalue for="modularity_class" value="3"/>
+        </attvalues>
+        <viz:size value="17.714287"/>
+        <viz:position x="-453.26874" y="-58.94648"/>
+        <viz:color r="194" g="245" b="91"/>
+      </node>
+      <node id="37" label="Chenildieu">
+        <attvalues>
+          <attvalue for="modularity_class" value="3"/>
+        </attvalues>
+        <viz:size value="17.714287"/>
+        <viz:position x="-386.44904" y="-140.05937"/>
+        <viz:color r="194" g="245" b="91"/>
+      </node>
+      <node id="38" label="Cochepaille">
+        <attvalues>
+          <attvalue for="modularity_class" value="3"/>
+        </attvalues>
+        <viz:size value="17.714287"/>
+        <viz:position x="-446.7876" y="-123.38005"/>
+        <viz:color r="194" g="245" b="91"/>
+      </node>
+      <node id="28" label="Fauchelevent">
+        <attvalues>
+          <attvalue for="modularity_class" value="4"/>
+        </attvalues>
+        <viz:size value="12.228573"/>
+        <viz:position x="-225.73984" y="-82.41631"/>
+        <viz:color r="245" g="194" b="91"/>
+      </node>
+      <node id="31" label="Simplice">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="12.228573"/>
+        <viz:position x="-281.4253" y="158.45137"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="54" label="LtGillenormand">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="12.228573"/>
+        <viz:position x="137.69348" y="-196.1069"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="2" label="MlleBaptistine">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="9.485714"/>
+        <viz:position x="-212.76357" y="-245.29176"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="3" label="MmeMagloire">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="9.485714"/>
+        <viz:position x="-242.82404" y="-235.26283"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="39" label="Pontmercy">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="9.485714"/>
+        <viz:position x="336.49738" y="269.55914"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="42" label="Anzelma">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="9.485714"/>
+        <viz:position x="189.69513" y="346.50662"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="43" label="Woman2">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="9.485714"/>
+        <viz:position x="-187.00418" y="145.02663"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="72" label="Toussaint">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="9.485714"/>
+        <viz:position x="40.942253" y="-113.78272"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="12" label="Marguerite">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="-339.77908" y="184.69139"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="30" label="Perpetue">
+        <attvalues>
+          <attvalue for="modularity_class" value="2"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="-403.92447" y="197.69823"/>
+        <viz:color r="91" g="194" b="245"/>
+      </node>
+      <node id="33" label="Woman1">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="-234.6001" y="113.15067"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="44" label="MotherInnocent">
+        <attvalues>
+          <attvalue for="modularity_class" value="4"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="-252.99521" y="-129.87549"/>
+        <viz:color r="245" g="194" b="91"/>
+      </node>
+      <node id="47" label="MmeBurgon">
+        <attvalues>
+          <attvalue for="modularity_class" value="5"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="488.13535" y="-356.8573"/>
+        <viz:color r="245" g="91" b="194"/>
+      </node>
+      <node id="50" label="Magnon">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="127.07365" y="113.05923"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="52" label="MmePontmercy">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="353.66415" y="205.89165"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="56" label="BaronessT">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="194.82993" y="-224.78036"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="73" label="Child1">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="437.939" y="-291.58234"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="74" label="Child2">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="6.742859"/>
+        <viz:position x="466.04922" y="-283.3606"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+      <node id="1" label="Napoleon">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-418.08344" y="-446.8853"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="4" label="CountessDeLo">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-379.30386" y="-429.06424"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="5" label="Geborand">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-417.26337" y="-406.03506"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="6" label="Champtercier">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-332.6012" y="-485.16974"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="7" label="Cravatte">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-382.69568" y="-475.09113"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="8" label="Count">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-320.384" y="-387.17325"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="9" label="OldMan">
+        <attvalues>
+          <attvalue for="modularity_class" value="0"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-344.39832" y="-451.16772"/>
+        <viz:color r="91" g="91" b="245"/>
+      </node>
+      <node id="10" label="Labarre">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-89.34107" y="-234.56128"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="13" label="MmeDeR">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-194.31313" y="-178.55301"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="14" label="Isabeau">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-158.05168" y="-201.99768"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="15" label="Gervais">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-127.701546" y="-242.55057"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="32" label="Scaufflaire">
+        <attvalues>
+          <attvalue for="modularity_class" value="1"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-122.41348" y="-210.37503"/>
+        <viz:color r="245" g="91" b="91"/>
+      </node>
+      <node id="40" label="Boulatruelle">
+        <attvalues>
+          <attvalue for="modularity_class" value="7"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="29.187843" y="460.13132"/>
+        <viz:color r="91" g="245" b="194"/>
+      </node>
+      <node id="45" label="Gribier">
+        <attvalues>
+          <attvalue for="modularity_class" value="4"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="-296.07935" y="-163.11964"/>
+        <viz:color r="245" g="194" b="91"/>
+      </node>
+      <node id="46" label="Jondrette">
+        <attvalues>
+          <attvalue for="modularity_class" value="5"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="550.3201" y="-522.4031"/>
+        <viz:color r="245" g="91" b="194"/>
+      </node>
+      <node id="53" label="MlleVaubois">
+        <attvalues>
+          <attvalue for="modularity_class" value="6"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="165.43939" y="-339.7736"/>
+        <viz:color r="194" g="91" b="245"/>
+      </node>
+      <node id="67" label="MotherPlutarch">
+        <attvalues>
+          <attvalue for="modularity_class" value="8"/>
+        </attvalues>
+        <viz:size value="4.0"/>
+        <viz:position x="668.9568" y="-204.65488"/>
+        <viz:color r="91" g="245" b="91"/>
+      </node>
+    </nodes>
+    <edges>
+      <edge id="0" source="1" target="0"/>
+      <edge id="1" source="2" target="0" weight="8.0"/>
+      <edge id="2" source="3" target="0" weight="10.0"/>
+      <edge id="3" source="3" target="2" weight="6.0"/>
+      <edge id="4" source="4" target="0"/>
+      <edge id="5" source="5" target="0"/>
+      <edge id="6" source="6" target="0"/>
+      <edge id="7" source="7" target="0"/>
+      <edge id="8" source="8" target="0" weight="2.0"/>
+      <edge id="9" source="9" target="0"/>
+      <edge id="13" source="11" target="0" weight="5.0"/>
+      <edge id="12" source="11" target="2" weight="3.0"/>
+      <edge id="11" source="11" target="3" weight="3.0"/>
+      <edge id="10" source="11" target="10"/>
+      <edge id="14" source="12" target="11"/>
+      <edge id="15" source="13" target="11"/>
+      <edge id="16" source="14" target="11"/>
+      <edge id="17" source="15" target="11"/>
+      <edge id="18" source="17" target="16" weight="4.0"/>
+      <edge id="19" source="18" target="16" weight="4.0"/>
+      <edge id="20" source="18" target="17" weight="4.0"/>
+      <edge id="21" source="19" target="16" weight="4.0"/>
+      <edge id="22" source="19" target="17" weight="4.0"/>
+      <edge id="23" source="19" target="18" weight="4.0"/>
+      <edge id="24" source="20" target="16" weight="3.0"/>
+      <edge id="25" source="20" target="17" weight="3.0"/>
+      <edge id="26" source="20" target="18" weight="3.0"/>
+      <edge id="27" source="20" target="19" weight="4.0"/>
+      <edge id="28" source="21" target="16" weight="3.0"/>
+      <edge id="29" source="21" target="17" weight="3.0"/>
+      <edge id="30" source="21" target="18" weight="3.0"/>
+      <edge id="31" source="21" target="19" weight="3.0"/>
+      <edge id="32" source="21" target="20" weight="5.0"/>
+      <edge id="33" source="22" target="16" weight="3.0"/>
+      <edge id="34" source="22" target="17" weight="3.0"/>
+      <edge id="35" source="22" target="18" weight="3.0"/>
+      <edge id="36" source="22" target="19" weight="3.0"/>
+      <edge id="37" source="22" target="20" weight="4.0"/>
+      <edge id="38" source="22" target="21" weight="4.0"/>
+      <edge id="47" source="23" target="11" weight="9.0"/>
+      <edge id="46" source="23" target="12" weight="2.0"/>
+      <edge id="39" source="23" target="16" weight="3.0"/>
+      <edge id="40" source="23" target="17" weight="3.0"/>
+      <edge id="41" source="23" target="18" weight="3.0"/>
+      <edge id="42" source="23" target="19" weight="3.0"/>
+      <edge id="43" source="23" target="20" weight="4.0"/>
+      <edge id="44" source="23" target="21" weight="4.0"/>
+      <edge id="45" source="23" target="22" weight="4.0"/>
+      <edge id="49" source="24" target="11" weight="7.0"/>
+      <edge id="48" source="24" target="23" weight="2.0"/>
+      <edge id="52" source="25" target="11" weight="12.0"/>
+      <edge id="51" source="25" target="23"/>
+      <edge id="50" source="25" target="24" weight="13.0"/>
+      <edge id="54" source="26" target="11" weight="31.0"/>
+      <edge id="55" source="26" target="16"/>
+      <edge id="53" source="26" target="24" weight="4.0"/>
+      <edge id="56" source="26" target="25"/>
+      <edge id="57" source="27" target="11" weight="17.0"/>
+      <edge id="58" source="27" target="23" weight="5.0"/>
+      <edge id="60" source="27" target="24"/>
+      <edge id="59" source="27" target="25" weight="5.0"/>
+      <edge id="61" source="27" target="26"/>
+      <edge id="62" source="28" target="11" weight="8.0"/>
+      <edge id="63" source="28" target="27"/>
+      <edge id="66" source="29" target="11" weight="2.0"/>
+      <edge id="64" source="29" target="23"/>
+      <edge id="65" source="29" target="27"/>
+      <edge id="67" source="30" target="23"/>
+      <edge id="69" source="31" target="11" weight="3.0"/>
+      <edge id="70" source="31" target="23" weight="2.0"/>
+      <edge id="71" source="31" target="27"/>
+      <edge id="68" source="31" target="30" weight="2.0"/>
+      <edge id="72" source="32" target="11"/>
+      <edge id="73" source="33" target="11" weight="2.0"/>
+      <edge id="74" source="33" target="27"/>
+      <edge id="75" source="34" target="11" weight="3.0"/>
+      <edge id="76" source="34" target="29" weight="2.0"/>
+      <edge id="77" source="35" target="11" weight="3.0"/>
+      <edge id="79" source="35" target="29" weight="2.0"/>
+      <edge id="78" source="35" target="34" weight="3.0"/>
+      <edge id="82" source="36" target="11" weight="2.0"/>
+      <edge id="83" source="36" target="29"/>
+      <edge id="80" source="36" target="34" weight="2.0"/>
+      <edge id="81" source="36" target="35" weight="2.0"/>
+      <edge id="87" source="37" target="11" weight="2.0"/>
+      <edge id="88" source="37" target="29"/>
+      <edge id="84" source="37" target="34" weight="2.0"/>
+      <edge id="85" source="37" target="35" weight="2.0"/>
+      <edge id="86" source="37" target="36" weight="2.0"/>
+      <edge id="93" source="38" target="11" weight="2.0"/>
+      <edge id="94" source="38" target="29"/>
+      <edge id="89" source="38" target="34" weight="2.0"/>
+      <edge id="90" source="38" target="35" weight="2.0"/>
+      <edge id="91" source="38" target="36" weight="2.0"/>
+      <edge id="92" source="38" target="37" weight="2.0"/>
+      <edge id="95" source="39" target="25"/>
+      <edge id="96" source="40" target="25"/>
+      <edge id="97" source="41" target="24" weight="2.0"/>
+      <edge id="98" source="41" target="25" weight="3.0"/>
+      <edge id="101" source="42" target="24"/>
+      <edge id="100" source="42" target="25" weight="2.0"/>
+      <edge id="99" source="42" target="41" weight="2.0"/>
+      <edge id="102" source="43" target="11" weight="3.0"/>
+      <edge id="103" source="43" target="26"/>
+      <edge id="104" source="43" target="27"/>
+      <edge id="106" source="44" target="11"/>
+      <edge id="105" source="44" target="28" weight="3.0"/>
+      <edge id="107" source="45" target="28" weight="2.0"/>
+      <edge id="108" source="47" target="46"/>
+      <edge id="112" source="48" target="11"/>
+      <edge id="110" source="48" target="25"/>
+      <edge id="111" source="48" target="27"/>
+      <edge id="109" source="48" target="47" weight="2.0"/>
+      <edge id="114" source="49" target="11" weight="2.0"/>
+      <edge id="113" source="49" target="26" weight="3.0"/>
+      <edge id="116" source="50" target="24"/>
+      <edge id="115" source="50" target="49"/>
+      <edge id="119" source="51" target="11" weight="2.0"/>
+      <edge id="118" source="51" target="26" weight="2.0"/>
+      <edge id="117" source="51" target="49" weight="9.0"/>
+      <edge id="121" source="52" target="39"/>
+      <edge id="120" source="52" target="51"/>
+      <edge id="122" source="53" target="51"/>
+      <edge id="125" source="54" target="26"/>
+      <edge id="124" source="54" target="49"/>
+      <edge id="123" source="54" target="51" weight="2.0"/>
+      <edge id="131" source="55" target="11" weight="19.0"/>
+      <edge id="132" source="55" target="16"/>
+      <edge id="133" source="55" target="25" weight="2.0"/>
+      <edge id="130" source="55" target="26" weight="21.0"/>
+      <edge id="128" source="55" target="39"/>
+      <edge id="134" source="55" target="41" weight="5.0"/>
+      <edge id="135" source="55" target="48" weight="4.0"/>
+      <edge id="127" source="55" target="49" weight="12.0"/>
+      <edge id="126" source="55" target="51" weight="6.0"/>
+      <edge id="129" source="55" target="54"/>
+      <edge id="136" source="56" target="49"/>
+      <edge id="137" source="56" target="55"/>
+      <edge id="139" source="57" target="41"/>
+      <edge id="140" source="57" target="48"/>
+      <edge id="138" source="57" target="55"/>
+      <edge id="145" source="58" target="11" weight="4.0"/>
+      <edge id="143" source="58" target="27" weight="6.0"/>
+      <edge id="142" source="58" target="48" weight="7.0"/>
+      <edge id="141" source="58" target="55" weight="7.0"/>
+      <edge id="144" source="58" target="57"/>
+      <edge id="148" source="59" target="48" weight="6.0"/>
+      <edge id="147" source="59" target="55" weight="5.0"/>
+      <edge id="149" source="59" target="57" weight="2.0"/>
+      <edge id="146" source="59" target="58" weight="15.0"/>
+      <edge id="150" source="60" target="48"/>
+      <edge id="151" source="60" target="58" weight="4.0"/>
+      <edge id="152" source="60" target="59" weight="2.0"/>
+      <edge id="153" source="61" target="48" weight="2.0"/>
+      <edge id="158" source="61" target="55"/>
+      <edge id="157" source="61" target="57"/>
+      <edge id="154" source="61" target="58" weight="6.0"/>
+      <edge id="156" source="61" target="59" weight="5.0"/>
+      <edge id="155" source="61" target="60" weight="2.0"/>
+      <edge id="164" source="62" target="41"/>
+      <edge id="162" source="62" target="48" weight="7.0"/>
+      <edge id="159" source="62" target="55" weight="9.0"/>
+      <edge id="163" source="62" target="57" weight="2.0"/>
+      <edge id="160" source="62" target="58" weight="17.0"/>
+      <edge id="161" source="62" target="59" weight="13.0"/>
+      <edge id="166" source="62" target="60" weight="3.0"/>
+      <edge id="165" source="62" target="61" weight="6.0"/>
+      <edge id="168" source="63" target="48" weight="5.0"/>
+      <edge id="174" source="63" target="55"/>
+      <edge id="170" source="63" target="57" weight="2.0"/>
+      <edge id="171" source="63" target="58" weight="4.0"/>
+      <edge id="167" source="63" target="59" weight="5.0"/>
+      <edge id="173" source="63" target="60" weight="2.0"/>
+      <edge id="172" source="63" target="61" weight="3.0"/>
+      <edge id="169" source="63" target="62" weight="6.0"/>
+      <edge id="184" source="64" target="11"/>
+      <edge id="177" source="64" target="48" weight="5.0"/>
+      <edge id="175" source="64" target="55" weight="5.0"/>
+      <edge id="183" source="64" target="57"/>
+      <edge id="179" source="64" target="58" weight="10.0"/>
+      <edge id="182" source="64" target="59" weight="9.0"/>
+      <edge id="181" source="64" target="60" weight="2.0"/>
+      <edge id="180" source="64" target="61" weight="6.0"/>
+      <edge id="176" source="64" target="62" weight="12.0"/>
+      <edge id="178" source="64" target="63" weight="4.0"/>
+      <edge id="187" source="65" target="48" weight="3.0"/>
+      <edge id="194" source="65" target="55" weight="2.0"/>
+      <edge id="193" source="65" target="57"/>
+      <edge id="189" source="65" target="58" weight="5.0"/>
+      <edge id="192" source="65" target="59" weight="5.0"/>
+      <edge id="191" source="65" target="60" weight="2.0"/>
+      <edge id="190" source="65" target="61" weight="5.0"/>
+      <edge id="188" source="65" target="62" weight="5.0"/>
+      <edge id="185" source="65" target="63" weight="5.0"/>
+      <edge id="186" source="65" target="64" weight="7.0"/>
+      <edge id="200" source="66" target="48"/>
+      <edge id="196" source="66" target="58" weight="3.0"/>
+      <edge id="197" source="66" target="59"/>
+      <edge id="203" source="66" target="60"/>
+      <edge id="202" source="66" target="61"/>
+      <edge id="198" source="66" target="62" weight="2.0"/>
+      <edge id="201" source="66" target="63"/>
+      <edge id="195" source="66" target="64" weight="3.0"/>
+      <edge id="199" source="66" target="65" weight="2.0"/>
+      <edge id="204" source="67" target="57" weight="3.0"/>
+      <edge id="206" source="68" target="11"/>
+      <edge id="207" source="68" target="24"/>
+      <edge id="205" source="68" target="25" weight="5.0"/>
+      <edge id="208" source="68" target="27"/>
+      <edge id="210" source="68" target="41"/>
+      <edge id="209" source="68" target="48"/>
+      <edge id="213" source="69" target="11"/>
+      <edge id="214" source="69" target="24"/>
+      <edge id="211" source="69" target="25" weight="6.0"/>
+      <edge id="215" source="69" target="27" weight="2.0"/>
+      <edge id="217" source="69" target="41"/>
+      <edge id="216" source="69" target="48"/>
+      <edge id="212" source="69" target="68" weight="6.0"/>
+      <edge id="221" source="70" target="11"/>
+      <edge id="222" source="70" target="24"/>
+      <edge id="218" source="70" target="25" weight="4.0"/>
+      <edge id="223" source="70" target="27"/>
+      <edge id="224" source="70" target="41"/>
+      <edge id="225" source="70" target="58"/>
+      <edge id="220" source="70" target="68" weight="4.0"/>
+      <edge id="219" source="70" target="69" weight="4.0"/>
+      <edge id="230" source="71" target="11"/>
+      <edge id="233" source="71" target="25"/>
+      <edge id="226" source="71" target="27"/>
+      <edge id="232" source="71" target="41"/>
+      <edge id="231" source="71" target="48"/>
+      <edge id="228" source="71" target="68" weight="2.0"/>
+      <edge id="227" source="71" target="69" weight="2.0"/>
+      <edge id="229" source="71" target="70" weight="2.0"/>
+      <edge id="236" source="72" target="11"/>
+      <edge id="234" source="72" target="26" weight="2.0"/>
+      <edge id="235" source="72" target="27"/>
+      <edge id="237" source="73" target="48" weight="2.0"/>
+      <edge id="238" source="74" target="48" weight="2.0"/>
+      <edge id="239" source="74" target="73" weight="3.0"/>
+      <edge id="242" source="75" target="25" weight="3.0"/>
+      <edge id="244" source="75" target="41"/>
+      <edge id="243" source="75" target="48"/>
+      <edge id="241" source="75" target="68" weight="3.0"/>
+      <edge id="240" source="75" target="69" weight="3.0"/>
+      <edge id="245" source="75" target="70"/>
+      <edge id="246" source="75" target="71"/>
+      <edge id="252" source="76" target="48"/>
+      <edge id="253" source="76" target="58"/>
+      <edge id="251" source="76" target="62"/>
+      <edge id="250" source="76" target="63"/>
+      <edge id="247" source="76" target="64"/>
+      <edge id="248" source="76" target="65"/>
+      <edge id="249" source="76" target="66"/>
+    </edges>
+  </graph>
+</gexf>

--- a/gephi-desktop/docs/Gephi_Toolkit/layout-and-preview.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/layout-and-preview.md
@@ -1,0 +1,122 @@
+---
+title: Layout, preview, and export
+sidebar_position: 7
+---
+
+Layout and preview are separate stages. A layout writes coordinates and sometimes sizes to graph elements. Preview reads those values and turns them into a rendered document such as SVG or PDF.
+
+## Run a layout for a fixed number of iterations
+
+Most layouts follow the same lifecycle:
+
+```java
+import org.gephi.layout.plugin.force.StepDisplacement;
+import org.gephi.layout.plugin.force.yifanHu.YifanHuLayout;
+
+YifanHuLayout layout = new YifanHuLayout(
+        null, new StepDisplacement(1f));
+layout.setGraphModel(graphModel);
+layout.resetPropertiesValues();
+layout.setOptimalDistance(200f);
+
+layout.initAlgo();
+try {
+    for (int i = 0; i < 100 && layout.canAlgo(); i++) {
+        layout.goAlgo();
+    }
+} finally {
+    layout.endAlgo();
+}
+```
+
+The lifecycle is:
+
+1. attach the workspace's `GraphModel`;
+2. load sensible defaults with `resetPropertiesValues()`;
+3. override the properties needed by your application;
+4. initialize, iterate while the algorithm can continue, and end it.
+
+The layout uses the current visible graph view. Filter before layout when hidden nodes should not influence placement.
+
+:::tip Bound server-side work
+
+Use a maximum iteration count or a time limit. Do not loop only on `canAlgo()` in a request handler: some force-directed layouts are designed to keep improving rather than reach a quick terminal state.
+
+:::
+
+## Run layouts for a duration
+
+`AutoLayout` divides a fixed duration among one or more algorithms:
+
+```java
+import java.util.concurrent.TimeUnit;
+import org.gephi.layout.plugin.AutoLayout;
+import org.gephi.layout.plugin.forceAtlas.ForceAtlasLayout;
+
+AutoLayout autoLayout = new AutoLayout(10, TimeUnit.SECONDS);
+autoLayout.setGraphModel(graphModel);
+
+ForceAtlasLayout forceAtlas = new ForceAtlasLayout(null);
+forceAtlas.resetPropertiesValues();
+forceAtlas.setAdjustSizes(Boolean.TRUE);
+
+autoLayout.addLayout(forceAtlas, 1.0f);
+autoLayout.execute();
+```
+
+The ratio `1.0f` gives this algorithm all the available time. Ratios can split the duration between several layouts. [`WithAutoLayout.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/WithAutoLayout.java) also demonstrates properties that change during execution.
+
+## Configure preview
+
+Preview options do not modify graph data. They control how the graph is drawn:
+
+```java
+import java.awt.Color;
+import org.gephi.preview.api.PreviewController;
+import org.gephi.preview.api.PreviewModel;
+import org.gephi.preview.api.PreviewProperty;
+import org.gephi.preview.types.EdgeColor;
+
+PreviewController previewController = Lookup.getDefault()
+        .lookup(PreviewController.class);
+PreviewModel previewModel = previewController.getModel(workspace);
+
+previewModel.getProperties().putValue(
+        PreviewProperty.SHOW_NODE_LABELS, Boolean.TRUE);
+previewModel.getProperties().putValue(
+        PreviewProperty.EDGE_CURVED, Boolean.FALSE);
+previewModel.getProperties().putValue(
+        PreviewProperty.EDGE_COLOR, new EdgeColor(Color.GRAY));
+previewModel.getProperties().putValue(
+        PreviewProperty.EDGE_THICKNESS, 0.1f);
+
+previewController.refreshPreview(workspace);
+```
+
+Use typed values of the expected kind: for example, `0.1f` for a float property and `Boolean.FALSE` for a boolean property.
+
+## Export a preview
+
+The extension chooses a preview exporter for SVG, PDF, or PNG:
+
+```java
+ExportController exportController = Lookup.getDefault()
+        .lookup(ExportController.class);
+exportController.exportFile(new File("network.svg"));
+```
+
+When several workspaces are open, configure the exporter explicitly, just as for graph export. For example, a PDF exporter can write to a file or a `ByteArrayOutputStream` and can be given a page size.
+
+If an exported image is blank or surprising, verify all of the following:
+
+- the intended workspace is current or set on the exporter;
+- nodes have finite coordinates;
+- the visible view contains nodes and edges;
+- preview was refreshed after the graph or its appearance changed;
+- labels are enabled if you expect to see them.
+
+[`HeadlessSimple.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/HeadlessSimple.java) demonstrates the complete filter-layout-statistics-appearance-preview-PDF pipeline.
+
+## Embedding a preview in Swing
+
+The Toolkit can render a preview into a Swing application, but this is not headless operation: it requires a graphical environment and Swing's event-dispatch rules. Start with [`PreviewJFrame.java`](https://github.com/gephi/gephi-toolkit-demos/blob/59c95188616066397b1f5d3ec8aff75e1ae05667/src/main/java/org/gephi/toolkit/demos/PreviewJFrame.java). On a server or in a container, export SVG, PDF, or PNG instead of creating a `JFrame`.

--- a/gephi-desktop/docs/Gephi_Toolkit/troubleshooting.md
+++ b/gephi-desktop/docs/Gephi_Toolkit/troubleshooting.md
@@ -1,0 +1,91 @@
+---
+title: Troubleshooting
+sidebar_position: 10
+---
+
+## `Lookup.lookup(...)` returns `null`
+
+The implementation module is not available to NetBeans Lookup. Confirm that:
+
+- the dependency is `org.gephi:gephi-toolkit:0.11.2`, not only an individual API JAR;
+- Maven resolved the dependency successfully;
+- packaging has not discarded `META-INF` service and NetBeans module metadata;
+- a minimized or shaded JAR has not merged service files incorrectly.
+
+Start with the normal Toolkit dependency and classpath before building a custom “fat JAR.”
+
+## `NoClassDefFoundError` or `ClassNotFoundException`
+
+The Toolkit's dependencies are missing at runtime. Running only your application JAR does not automatically add Maven dependencies to the classpath. During development, use `mvn exec:java` or run from an IDE with Maven support.
+
+The standard `gephi-toolkit` artifact declares its dependencies. The release also provides an `-all` JAR when a single distributable Toolkit JAR is needed, but your own application dependencies still need appropriate packaging.
+
+## Import succeeds but the graph is empty
+
+Check the container report before processing and print counts immediately afterward:
+
+```java
+Workspace workspace = importController.process(container);
+Graph graph = graphController.getGraphModel(workspace).getGraph();
+System.out.printf("nodes=%d edges=%d%n",
+        graph.getNodeCount(), graph.getEdgeCount());
+```
+
+Common causes are an empty input, wrong CSV role settings, edges referring to unknown IDs while auto-node creation is disabled, or reading a different file than expected.
+
+## The wrong graph is exported
+
+In multi-workspace programs, set the workspace on the exporter explicitly. If a filter is involved, also decide between the full and visible graph:
+
+```java
+GraphExporter exporter = (GraphExporter) exportController.getExporter("gexf");
+exporter.setWorkspace(workspace);
+exporter.setExportVisible(true);
+```
+
+Without `setExportVisible(true)`, graph exporters normally serialize the full graph.
+
+## A layout does not stop
+
+Force-directed layouts may keep improving for as long as they are allowed to run. Bound the loop with an iteration counter, use `AutoLayout` with a duration, and always call `endAlgo()` in a `finally` block.
+
+## Maven appears to hang after the program finishes
+
+Gephi, NetBeans modules, or a database driver can leave harmless daemon threads alive. With `exec-maven-plugin`, set:
+
+```xml
+<cleanupDaemonThreads>false</cleanupDaemonThreads>
+```
+
+This is a launcher concern, not a reason to call `System.exit` throughout library code.
+
+## Preview export is blank
+
+Verify that you configured the `PreviewModel` belonging to the same workspace as the exporter, that the visible view is not empty, and that nodes have coordinates. Refresh preview after graph, layout, or appearance changes.
+
+## Code from an old tutorial no longer compiles or imports dynamic data
+
+Match documentation, demos, Javadoc, and dependency versions. For 0.11.2, use the [0.11.2 Javadoc](https://javadoc.io/doc/org.gephi/gephi-toolkit/0.11.2/index.html) and the [0.11.2 demo update](https://github.com/gephi/gephi-toolkit-demos/pull/18). In particular, replace the old `newProject()`-before-import pattern with `importController.process(container)`.
+
+## Get help
+
+Before asking for help, reduce the problem to a small program and include:
+
+- Java, Maven, and Toolkit versions;
+- the complete exception and its cause chain;
+- input format and a minimal sample when possible;
+- whether the application is headless, multi-threaded, or uses multiple workspaces.
+
+Use [Gephi Discussions](https://github.com/gephi/gephi/discussions) for usage questions, [Toolkit issues](https://github.com/gephi/gephi-toolkit/issues) for Toolkit packaging problems, and [documentation issues](https://github.com/gephi/gephi-documentation/issues) for this guide.
+
+## End of the Gephi Toolkit guide
+
+You have reached the end of the Gephi Toolkit documentation. You should now be able to create a Java project, import or build a graph, analyze and lay it out, then export the result without using Gephi Desktop.
+
+For complete working programs, continue with the [Gephi Toolkit demos](https://github.com/gephi/gephi-toolkit-demos). Use the [0.11.2 Javadoc](https://javadoc.io/doc/org.gephi/gephi-toolkit/0.11.2/index.html) when you need the full contract of a class or method.
+
+:::info The next section is about Gephi plugins
+
+The **Next** link below leaves the Toolkit guide and opens the [Gephi plugin development documentation](../Plugins/index.md). Plugins extend the Gephi Desktop application and follow a different development model. You do not need a plugin to build a standalone application with the Toolkit.
+
+:::


### PR DESCRIPTION
Adds a structured Gephi Toolkit guide for Gephi 0.11.2 and Java 17, covering setup, graph models, import and export, filtering and analysis, layouts and preview, dynamic graphs, workspaces, concurrency, server applications, and troubleshooting. Includes a runnable GEXF example. Validation: the Docusaurus desktop production build succeeds.